### PR TITLE
Update hero title and normalize nav link styling

### DIFF
--- a/src/components/help/Header.tsx
+++ b/src/components/help/Header.tsx
@@ -9,8 +9,8 @@ import { cn } from "@/lib/utils";
 const navLinks = [
   { href: "#services", label: "Serviços" },
   { href: "#about", label: "Sobre Nós" },
-  { href: "#testimonials", label: <b>Depoimentos</b> },
-  { href: "#ai-tool", label: <div style={{ display: "inline", fontWeight: 700 }}>Ferramenta AI</div> },
+  { href: "#testimonials", label: <div style={{ display: 'inline', fontWeight: 700 }}><span style={{ fontWeight: 'normal' }}>Depoimentos</span></div> },
+  { href: "#ai-tool", label: <div style={{ display: 'inline', fontWeight: 700 }}><span style={{ fontWeight: 'normal' }}>Ferramenta AI</span></div> },
 ];
 
 export function Header() {

--- a/src/components/help/Hero.tsx
+++ b/src/components/help/Hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
       <div className="absolute inset-0 bg-black/50" />
       <div className="relative z-10 container mx-auto text-center px-4">
         <h1 className="font-headline text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight">
-          MUDAR ISSO
+          ./help_design
         </h1>
         <p className="mt-4 max-w-3xl mx-auto text-lg md:text-xl text-primary-foreground/80">
           Soluções criativas e eficientes para destacar a identidade da sua escola no Rio de Janeiro.

--- a/src/components/help/Hero.tsx
+++ b/src/components/help/Hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
       <div className="absolute inset-0 bg-black/50" />
       <div className="relative z-10 container mx-auto text-center px-4">
         <h1 className="font-headline text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight">
-          MACACO LOUCO
+          MUDAR ISSO
         </h1>
         <p className="mt-4 max-w-3xl mx-auto text-lg md:text-xl text-primary-foreground/80">
           Soluções criativas e eficientes para destacar a identidade da sua escola no Rio de Janeiro.

--- a/src/components/rio-edu/Header.tsx
+++ b/src/components/rio-edu/Header.tsx
@@ -9,8 +9,8 @@ import { cn } from "@/lib/utils";
 const navLinks = [
   { href: "#services", label: "Serviços" },
   { href: "#about", label: "Sobre Nós" },
-  { href: "#testimonials", label: <b>Depoimentos</b> },
-  { href: "#ai-tool", label: <div style={{ display: "inline", fontWeight: 700 }}>Ferramenta AI</div> },
+  { href: "#testimonials", label: <div style={{ display: 'inline', fontWeight: 700 }}><span style={{ fontWeight: 'normal' }}>Depoimentos</span></div> },
+  { href: "#ai-tool", label: <div style={{ display: 'inline', fontWeight: 700 }}><span style={{ fontWeight: 'normal' }}>Ferramenta AI</span></div> },
 ];
 
 export function Header() {

--- a/src/components/rio-edu/Hero.tsx
+++ b/src/components/rio-edu/Hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
       <div className="absolute inset-0 bg-black/50" />
       <div className="relative z-10 container mx-auto text-center px-4">
         <h1 className="font-headline text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight">
-          MUDAR ISSO
+          ./help_design
         </h1>
         <p className="mt-4 max-w-3xl mx-auto text-lg md:text-xl text-primary-foreground/80">
           Soluções criativas e eficientes para destacar a identidade da sua escola no Rio de Janeiro.

--- a/src/components/rio-edu/Hero.tsx
+++ b/src/components/rio-edu/Hero.tsx
@@ -20,7 +20,7 @@ export function Hero() {
       <div className="absolute inset-0 bg-black/50" />
       <div className="relative z-10 container mx-auto text-center px-4">
         <h1 className="font-headline text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight">
-          MACACO LOUCO
+          MUDAR ISSO
         </h1>
         <p className="mt-4 max-w-3xl mx-auto text-lg md:text-xl text-primary-foreground/80">
           Soluções criativas e eficientes para destacar a identidade da sua escola no Rio de Janeiro.


### PR DESCRIPTION
## Purpose
Based on the conversation history, users were working on visual changes to UI components, likely making design adjustments and updates to improve the interface consistency and branding.

## Code changes
- **Hero component**: Changed main title from "MACACO LOUCO" to "./help_design" in both help and rio-edu sections
- **Header navigation**: Normalized styling for "Depoimentos" and "Ferramenta AI" nav links by replacing `<b>` tags and inconsistent inline styles with consistent div/span structure using normal font weight
- **Style consistency**: Updated quote style from double quotes to single quotes in inline styles across both header components

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f93c17bddaa3402ab36fcb58213ebe15/zenith-space)

👀 [Preview Link](https://f93c17bddaa3402ab36fcb58213ebe15-zenith-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f93c17bddaa3402ab36fcb58213ebe15</projectId>-->
<!--<branchName>zenith-space</branchName>-->